### PR TITLE
Fix: Order DailyFlowRun objects by date and get the most recent one

### DIFF
--- a/healthbuddy_backend/celery.py
+++ b/healthbuddy_backend/celery.py
@@ -13,7 +13,7 @@ app.config_from_object('django.conf:settings', namespace='CELERY')
 app.conf.beat_schedule = {
     'sync-daily-flow-run': {
         'task': 'sync-daily-flow-run',
-        'schedule': crontab(minute=00, hour=23)
+        'schedule': crontab(minute=00, hour=00)
     },
     'sync-daily-group-count': {
         'task': 'sync-daily-group-count',

--- a/healthbuddy_backend/rapidpro/tasks.py
+++ b/healthbuddy_backend/rapidpro/tasks.py
@@ -31,7 +31,7 @@ def sync_daily_flow_run():
 
     final_result = {}
 
-    last_item = DailyFlowRuns.objects.last()
+    last_item = DailyFlowRuns.objects.order_by('-day').first()
     if last_item:
         last_day = last_item.day
         last_day = last_day.strftime("%Y-%m-%d")

--- a/healthbuddy_backend/rapidpro/tasks.py
+++ b/healthbuddy_backend/rapidpro/tasks.py
@@ -31,7 +31,7 @@ def sync_daily_flow_run():
 
     final_result = {}
 
-    last_item = DailyFlowRuns.objects.order_by('-day').first()
+    last_item = DailyFlowRuns.objects.order_by('day').last()
     if last_item:
         last_day = last_item.day
         last_day = last_day.strftime("%Y-%m-%d")

--- a/healthbuddy_backend/rapidpro/tasks.py
+++ b/healthbuddy_backend/rapidpro/tasks.py
@@ -1,5 +1,5 @@
 import requests
-from datetime import datetime
+from datetime import datetime, time, timedelta
 from celery.task import task
 from django.conf import settings
 from django.utils import timezone
@@ -33,9 +33,11 @@ def sync_daily_flow_run():
 
     last_item = DailyFlowRuns.objects.order_by('day').last()
     if last_item:
-        last_day = last_item.day
+        last_day = last_item.day + timedelta(days=1)
         last_day = last_day.strftime("%Y-%m-%d")
-        next_ = f"{next_}?after={last_day}"
+        yesterdayMaxTime = datetime.combine(datetime.now() - timedelta(days=1), time.max)
+        yesterdayMaxTime = yesterdayMaxTime.strftime("%Y-%m-%dT%H:%M:%S.%f")
+        next_ = f"{next_}?after={last_day}&before={yesterdayMaxTime}"
 
     while next_:
         response = requests.get(next_, headers=headers)


### PR DESCRIPTION
- The previous `DailyFlowRun.objects.last()` was not returning the most recent object, leading the task to create duplicate data.